### PR TITLE
Implement quadrilaterals and update how we add meshes to world object list

### DIFF
--- a/src/include/primitive_shapes/hittable_list.h
+++ b/src/include/primitive_shapes/hittable_list.h
@@ -7,6 +7,9 @@
 #include "hittable.h"
 #include "../acceleration/bvh_util.h"
 #include "../geometry/vec3.h"
+#include "triangle.h"
+#include "quadrilateral.h"
+
 using std::make_shared;
 using std::shared_ptr;
 
@@ -20,8 +23,18 @@ public:
 
     void clear() { objects.clear(); }
 
-    void add(shared_ptr<hittable> object) {
+    void add(std::shared_ptr<hittable> object) {
         objects.push_back(object);
+    }
+
+    void add(triangleMesh* mesh) {
+        for (int i = 0; i < mesh->num_triangles; i++) {
+            objects.push_back(std::make_shared<triangle>(mesh, i, mesh->mat));
+        }
+    }
+
+    void add(quadrilateral *quad) {
+        add(&quad->mesh);
     }
 
 bool intersect(BVHTreeNode* head, const ray& r, interval ray_t, hit_record& rec) const {

--- a/src/include/primitive_shapes/quadrilateral.h
+++ b/src/include/primitive_shapes/quadrilateral.h
@@ -1,0 +1,24 @@
+#ifndef QUAD_H
+#define QUAD_H
+
+#include <iostream>
+#include "./hittable.h"
+#include "triangle.h"
+#include "../geometry/vec3.h"
+#include "../materials/bxdf.h"
+#include "../materials/diffuseBXDF.h"
+
+struct quadrilateral {
+    triangleMesh mesh;
+    std::shared_ptr<bxdf> mat; // Material for the sphere
+    // Constructor with material
+    quadrilateral();
+    quadrilateral(const vec3h& origin, const vec3h& dir_a, const vec3h& dir_b, std::shared_ptr<bxdf> material)
+        : mesh(
+            std::vector<vec3h>{ origin, origin + dir_a, origin + dir_b, origin + dir_a + dir_b },
+            std::vector<int>{ 0, 1, 2, 1, 2, 3 },
+            2, material
+          ){}
+};
+
+#endif

--- a/src/include/primitive_shapes/sphere.h
+++ b/src/include/primitive_shapes/sphere.h
@@ -47,10 +47,24 @@ std::shared_ptr<bxdf> mat; // Material for the sphere
         rec.t = root;
         rec.p = r.line(rec.t);
         rec.mat = mat;
-        rec.normal = (rec.p - center) / radius;
+        vec3h outward_normal = (rec.p - center) / radius;
+        rec.set_face_normal(r, outward_normal);
+        get_sphere_uv(outward_normal, rec.u, rec.v);
         // Set the normal, point, and ray direction scalar to hit record
         return true;
     }   
+
+    static void get_sphere_uv(const vec3h& p, double& u, double& v) {
+        // Normalized angles u: phi, v: theta
+        // u: returned value [0,1] of angle around the Y axis from X=-1.
+        // v: returned value [0,1] of angle from Y=-1 to Y=+1.
+
+        auto theta = std::acos(-p.y);
+        auto phi = std::atan2(-p.z, p.x) + pi;
+
+        u = phi / (2*pi);
+        v = theta / pi;
+    }
 
     Bounds3f bounds() const { 
         vec3h pmin = center - vec3h(radius, radius, radius, 1);  // Center minus radius

--- a/src/include/primitive_shapes/triangle.h
+++ b/src/include/primitive_shapes/triangle.h
@@ -33,7 +33,7 @@ struct triangleMesh {
 
 class triangle : public hittable {
 private:
-    triangleMesh* mesh = nullptr;;
+    triangleMesh* mesh = nullptr;
     int mesh_index;
     triangleIntersection check_intersection(const ray& r, interval ray_t, vec3h p0, vec3h p1, vec3h p2) const;
     void permutation(vec3h direction, vec3h& dirt, vec3h& p0t, vec3h& p1t, vec3h& p2t) const;
@@ -232,7 +232,7 @@ Bounds3f triangle::bounds() const  {
 
 void triangleMesh::load_objects(std::vector<shared_ptr<hittable>>& objects) {
     for (int i = 0; i < num_triangles; i++) {
-        objects.push_back(make_shared<triangle>(this, i - 1, mat));
+        objects.push_back(make_shared<triangle>(this, i, mat));
     }
 }
 


### PR DESCRIPTION
Previously implementation wasn't using the universal syntax of 

hittable_list.add(object to add). Modified so we can add a mesh into the hittable list, and it will loop through adding all triangles to the object list. 